### PR TITLE
Be able to send multiple messages in single request.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -59,8 +59,8 @@ class Client
     }
 
     /**
-     * @param string|array $number
-     * @param string $message
+     * @param string|array|null $number
+     * @param string|array $message
      * @param string $sender
      * @param int|null $route
      * @param string|null $country
@@ -68,16 +68,19 @@ class Client
      */
     public function sms($number, $message, $sender = null, $route = null, $country = null)
     {
+        if (is_string($message)) {
+            $message = [[
+                'message' => $message,
+                'to' => (array) $number,
+            ]];
+        }
         $response = $this->http->post(self::ENDPOINT_SMS, [
             'headers' => ['authkey' => $this->key],
             'json' => [
                 'country' => $country ?? config('msg91.default_country'),
                 'route' => $route ?? config('msg91.default_route'),
                 'sender' => $sender ?? config('msg91.default_sender'),
-                'sms' => [[
-                    'message' => $message,
-                    'to' => (array) $number,
-                ]],
+                'sms' => $message,
             ],
         ]);
         if ($response->getStatusCode() === 200) {

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Facade as LaravelFacade;
  * @package Laravel\Msg91
  *
  * @method static bool otp(string $number, string $sender = null, string $message = null)
- * @method static string|false sms(string $number, string $message, string $sender = null, int $route = null, string $country = null)
+ * @method static string|false sms(string|array|null $number, string|array $message, string $sender = null, int $route = null, string $country = null)
  * @method static bool verify(string $number, string $otp)
  */
 class Facade extends LaravelFacade


### PR DESCRIPTION
These changes allow library user(s) to send multiple SMS in since call as documented at https://docs.msg91.com/collection/msg91-api-integration/5/send-sms-v2/TZ2IXQHS.